### PR TITLE
PHP 8.1 compat: \IteratorAggregate::getIterator() must return \Traversable

### DIFF
--- a/src/Assertion/UniqueAssertionCollection.php
+++ b/src/Assertion/UniqueAssertionCollection.php
@@ -45,9 +45,9 @@ class UniqueAssertionCollection implements \IteratorAggregate
     }
 
     /**
-     * @return \Iterator<int, AssertionInterface>
+     * @return \Traversable<int, AssertionInterface>
      */
-    public function getIterator(): \Iterator
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->assertions);
     }


### PR DESCRIPTION
Fixes #203