### PR TITLE
StepCollectionInterface::getNames() must not alter name order

### DIFF
--- a/src/Step/StepCollection.php
+++ b/src/Step/StepCollection.php
@@ -29,10 +29,7 @@ class StepCollection implements StepCollectionInterface
 
     public function getStepNames(): array
     {
-        $names = $this->iteratorIndex;
-        sort($names);
-
-        return $names;
+        return $this->iteratorIndex;
     }
 
     public function current(): ?StepInterface

--- a/tests/Unit/Step/StepCollectionTest.php
+++ b/tests/Unit/Step/StepCollectionTest.php
@@ -59,9 +59,9 @@ class StepCollectionTest extends \PHPUnit\Framework\TestCase
                     'alpha' => new Step([], []),
                 ]),
                 'expectedNames' => [
-                    'alpha',
-                    'charlie',
                     'zulu',
+                    'charlie',
+                    'alpha',
                 ],
             ],
         ];


### PR DESCRIPTION
Fixes #212