### PR TITLE
TestParser throws InvalidTestException if config.browser or config.url is empty

### DIFF
--- a/src/Parser/Exception/InvalidTestException.php
+++ b/src/Parser/Exception/InvalidTestException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace webignition\BasilModels\Parser\Exception;
+
+class InvalidTestException extends \Exception
+{
+    public const CODE_BROWSER_EMPTY = 100;
+    public const CODE_URL_EMPTY = 200;
+
+    public static function createForEmptyBrowser(): self
+    {
+        return new InvalidTestException(
+            'config.browser is empty',
+            self::CODE_BROWSER_EMPTY
+        );
+    }
+
+    public static function createForEmptyUrl(): self
+    {
+        return new InvalidTestException(
+            'config.url is empty',
+            self::CODE_URL_EMPTY
+        );
+    }
+}

--- a/src/Parser/Test/TestParser.php
+++ b/src/Parser/Test/TestParser.php
@@ -8,6 +8,7 @@ use webignition\BasilModels\Model\Step\StepCollection;
 use webignition\BasilModels\Model\Test\Test;
 use webignition\BasilModels\Model\Test\TestInterface;
 use webignition\BasilModels\Parser\DataParserInterface;
+use webignition\BasilModels\Parser\Exception\InvalidTestException;
 use webignition\BasilModels\Parser\Exception\UnparseableStepException;
 use webignition\BasilModels\Parser\Exception\UnparseableTestException;
 use webignition\BasilModels\Parser\StepParser;
@@ -35,6 +36,7 @@ class TestParser implements DataParserInterface
      * @param array<mixed> $data
      *
      * @throws UnparseableTestException
+     * @throws InvalidTestException
      */
     public function parse(array $data): TestInterface
     {
@@ -42,10 +44,16 @@ class TestParser implements DataParserInterface
         $configurationData = is_array($configurationData) ? $configurationData : [];
 
         $browser = $configurationData[self::KEY_BROWSER] ?? '';
-        $browser = is_string($browser) ? $browser : '';
+        $browser = is_string($browser) ? trim($browser) : '';
+        if ('' === $browser) {
+            throw InvalidTestException::createForEmptyBrowser();
+        }
 
         $url = $configurationData[self::KEY_URL] ?? '';
-        $url = is_string($url) ? $url : '';
+        $url = is_string($url) ? trim($url) : '';
+        if ('' === $url) {
+            throw InvalidTestException::createForEmptyUrl();
+        }
 
         $stepName = null;
 

--- a/tests/Unit/Parser/Test/TestParserTest.php
+++ b/tests/Unit/Parser/Test/TestParserTest.php
@@ -12,6 +12,7 @@ use webignition\BasilModels\Model\Step\Step;
 use webignition\BasilModels\Model\Step\StepCollection;
 use webignition\BasilModels\Model\Test\Test;
 use webignition\BasilModels\Model\Test\TestInterface;
+use webignition\BasilModels\Parser\Exception\InvalidTestException;
 use webignition\BasilModels\Parser\Exception\UnparseableActionException;
 use webignition\BasilModels\Parser\Exception\UnparseableStepException;
 use webignition\BasilModels\Parser\Exception\UnparseableTestException;
@@ -26,6 +27,85 @@ class TestParserTest extends TestCase
         parent::setUp();
 
         $this->parser = TestParser::create();
+    }
+
+    /**
+     * @dataProvider parseThrowsEmptyBrowserExceptionDataProvider
+     *
+     * @param array<mixed> $testData
+     */
+    public function testParseThrowsEmptyBrowserException(array $testData): void
+    {
+        self::expectException(InvalidTestException::class);
+        self::expectExceptionMessage('config.browser is empty');
+
+        $this->parser->parse($testData);
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function parseThrowsEmptyBrowserExceptionDataProvider(): array
+    {
+        return [
+            'no test data' => [
+                'testData' => [],
+            ],
+            'empty' => [
+                'testData' => [
+                    'config' => [
+                        'browser' => '',
+                        'url' => 'http://example.com/',
+                    ],
+                ],
+            ],
+            'whitespace-only' => [
+                'testData' => [
+                    'config' => [
+                        'browser' => '  ',
+                        'url' => 'http://example.com/',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider parseThrowsEmptyUrlExceptionDataProvider
+     *
+     * @param array<mixed> $testData
+     */
+    public function testParseThrowsEmptyUrlException(array $testData): void
+    {
+        self::expectException(InvalidTestException::class);
+        self::expectExceptionMessage('config.url is empty');
+
+        $this->parser->parse($testData);
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function parseThrowsEmptyUrlExceptionDataProvider(): array
+    {
+        return [
+            'empty' => [
+                'testData' => [
+                    'config' => [
+                        'browser' => 'chrome',
+                        'url' => '',
+                    ],
+                ],
+            ],
+            'whitespace-only' => [
+                'testData' => [
+                    'config' => [
+                        'browser' => 'chrome',
+                        'url' => '  ',
+                    ],
+                ],
+            ],
+        ];
     }
 
     /**
@@ -44,14 +124,6 @@ class TestParserTest extends TestCase
     public function parseDataProvider(): array
     {
         return [
-            'empty' => [
-                'testData' => [],
-                'expectedTest' => new Test(
-                    '',
-                    '',
-                    new StepCollection([])
-                ),
-            ],
             'non-empty' => [
                 'testData' => [
                     'config' => [
@@ -125,6 +197,10 @@ class TestParserTest extends TestCase
     public function testParseTestWithStepWithEmptyAction(): void
     {
         $testData = [
+            'config' => [
+                'browser' => 'chrome',
+                'url' => 'http://example.com',
+            ],
             'step name' => [
                 'actions' => [
                     '',


### PR DESCRIPTION
Fixes #226